### PR TITLE
added option for saving frames to a user provided directory.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ optional arguments:
   -t THRESHOLD, --threshold THRESHOLD
                         default threshold is 100.0. Use 10-30 for motion
   -s STEP, --step STEP  frame step size
+  --save SAVE           path to save the frames in a directory
 ```
 
 Example usage:

--- a/vid2img.py
+++ b/vid2img.py
@@ -1,6 +1,7 @@
 import sys
 import cv2
 import argparse
+import os
 
 
 print("OpenCV version"+cv2.__version__)
@@ -23,6 +24,7 @@ optional.add_argument("-t", "--threshold", type=float, default=100.0,
                       help="default threshold is 100.0. Use 10-30 for motion")
 optional.add_argument("-s", "--step", type=int,
                       default=1, help="frame step size")
+optional.add_argument("--save", default= "", type= str, help= "path to save the frames in a directory")
 args = vars(parser.parse_args())
 
 if not args["path"]:
@@ -46,7 +48,8 @@ while success:
     if frameStep == step:
         if fm > args["threshold"]:
             savedFrame += 1
-            cv2.imwrite("frame%d.png" % count, image)
+            image_path = os.path.join(args["save"], "frame%d.png" % count)
+            cv2.imwrite(image_path, image)
         frameStep = 0
 
     if fm < args["threshold"]:


### PR DESCRIPTION
I was converting video to images, I found out that it is saving images in the same directory as the script located. However, I wanted to save in a separate directory. Therefore, I added option for the users to define their separate directory if they want. This will help save the images to a directory where a user wants, specially for data annotations purposes. 